### PR TITLE
Refactor

### DIFF
--- a/lib/facter/sshpubkey.rb
+++ b/lib/facter/sshpubkey.rb
@@ -5,14 +5,12 @@ Etc.passwd do |pw|
   homedir = pw.dir
   key = false
 
-  if File.exists?("#{homedir}/.ssh/id_rsa.pub")
-    key = IO.read("#{homedir}/.ssh/id_rsa.pub")
-  elsif File.exists?("#{homedir}/.ssh/id_dsa.pub")
-    key = IO.read("#{homedir}/.ssh/id_dsa.pub")
+  if File.exists?("#{homedir}/.ssh/rsnapshot.rsa.pub")
+    key = IO.read("#{homedir}/.ssh/rsnapshot.rsa.pub")
   end
 
   if key
-    Facter.add("sshpubkey_#{user}") do
+    Facter.add("sshpubkey_rsnapshot") do
       setcode do
         key
       end

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -1,16 +1,22 @@
 class rsnapshot::master(
   $location_name,
-  $exclusions = [],
+  $exclusions    = [],
+  $snapshot_root = $rsnapshot::params::snapshot_root,
+  $retain        = $rsnapshot::params::retain,
+  $options       = $rsnapshot::params::options,
+  $verbose       = $rsnapshot::params::verbose,
+  $loglevel_     = $rsnapshot::params::loglevel,
+  $logfile       = $rsnapshot::params::logfile,
 ) inherits rsnapshot::params {
+
+  validate_absolute_path($snapshot_root)
 
   Class["${module_name}::master::install"] ->
   Class["${module_name}::master::config"]
   contain "${module_name}::master::install"
   contain "${module_name}::master::config"
 
-  Rsnapshot::Master::Node_definition <<| to_location == $location_name |>> {
-    require => Class['Rsnapshot::Master::Config']
-  }
+  Rsnapshot::Master::Node_definition <<| to_location == $location_name |>>
 
   @@rsnapshot::node::master_definition { $::fqdn:
     location_name => $location_name,

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -7,14 +7,26 @@ class rsnapshot::master(
   $verbose       = $rsnapshot::params::verbose,
   $loglevel_     = $rsnapshot::params::loglevel,
   $logfile       = $rsnapshot::params::logfile,
+  $hourly_hour   = $rsnapshot::params::hourly_hour,
+  $hourly_minute = $rsnapshot::params::hourly_minute,
+  $daily_hour    = $rsnapshot::params::daily_hour,
+  $daily_minute  = $rsnapshot::params::daily_minute,
+  $weekly_hour    = $rsnapshot::params::weekly_hour,
+  $weekly_minute  = $rsnapshot::params::weekly_minute,
+  $weekly_weekday = $rsnapshot::params::weekly_weekday,
+  $monthly_hour     = $rsnapshot::params::monthly_hour,
+  $monthly_minute   = $rsnapshot::params::monthly_minute,
+  $monthly_monthday = $rsnapshot::params::monthly_monthday,
 ) inherits rsnapshot::params {
 
   validate_absolute_path($snapshot_root)
 
   Class["${module_name}::master::install"] ->
-  Class["${module_name}::master::config"]
+  Class["${module_name}::master::config"] ->
+  Class["${module_name}::master::cron"]
   contain "${module_name}::master::install"
   contain "${module_name}::master::config"
+  contain "${module_name}::master::cron"
 
   Rsnapshot::Master::Node_definition <<| to_location == $location_name |>>
 

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -14,6 +14,6 @@ class rsnapshot::master(
 
   @@rsnapshot::node::master_definition { $::fqdn:
     location_name => $location_name,
-    sshpubkey     => $::sshpubkey_root,
+    sshpubkey     => $::sshpubkey_rsnapshot,
   }
 }

--- a/manifests/master/config.pp
+++ b/manifests/master/config.pp
@@ -18,26 +18,4 @@ class rsnapshot::master::config inherits rsnapshot::master {
     command  => "/usr/bin/ssh-keygen -t rsa -b 2048 -f /root/.ssh/rsnapshot.rsa -N '' -C 'root@${::fqdn}'",
     creates  => '/root/.ssh/rsnapshot.rsa',
   }
-
-  cron { 'rsnapshot hourly':
-    user    => root,
-    hour    => '*/6',
-    minute  => 0,
-    command => 'rsnapshot hourly'
-  }
-
-  cron { 'rsnapshot daily':
-    user    => root,
-    hour    => 4,
-    minute  => 0,
-    command => 'rsnapshot daily'
-  }
-
-  cron { 'rsnapshot weekly':
-    user    => root,
-    hour    => 2,
-    minute  => 0,
-    weekday => 0,
-    command => 'rsnapshot weekly'
-  }
 }

--- a/manifests/master/config.pp
+++ b/manifests/master/config.pp
@@ -13,9 +13,9 @@ class rsnapshot::master::config inherits rsnapshot::master {
     line    => "snapshot_root\t/var/backups/rsnapshot/",
   }
 
-  exec { 'generate private ssh key':
-    command  => "/usr/bin/ssh-keygen -f /root/.ssh/id_rsa -N '' -C 'root@${::fqdn}'",
-    creates  => '/root/.ssh/id_rsa',
+  exec { 'generate rsnasphot private ssh key':
+    command  => "/usr/bin/ssh-keygen -t rsa -b 2048 -f /root/.ssh/rsnapshot.rsa -N '' -C 'root@${::fqdn}'",
+    creates  => '/root/.ssh/rsnapshot.rsa',
   }
 
   file_line { 'cmd_ssh':

--- a/manifests/master/cron.pp
+++ b/manifests/master/cron.pp
@@ -1,0 +1,28 @@
+class rsnapshot::master::cron inherits rsnapshot::master {
+  cron { 'rsnapshot hourly':
+    user    => 'root',
+    hour    => $hourly_hour,
+    minute  => $hourly_minute,
+    command => 'rsnapshot hourly'
+  }
+  cron { 'rsnapshot daily':
+    user    => 'root',
+    hour    => $daily_hour,
+    minute  => $daily_minute,
+    command => 'rsnapshot daily'
+  }
+  cron { 'rsnapshot weekly':
+    user    => 'root',
+    hour    => $weekly_hour,
+    minute  => $weekly_minute,
+    weekday => $weekly_weekday,
+    command => 'rsnapshot weekly'
+  }
+  cron { 'rsnapshot monthly':
+    user    => 'root',
+    hour    => $monthly_hour,
+    minute  => $monthly_minute,
+    monthday => $monthly_monthday,
+    command => 'rsnapshot monthly'
+  }
+}

--- a/manifests/master/exclusion.pp
+++ b/manifests/master/exclusion.pp
@@ -1,8 +1,8 @@
 define rsnapshot::master::exclusion() {
   include rsnapshot::params
-  file_line { "exclude_${name}":
-    ensure  => present,
-    path    => $rsnapshot::params::config_path,
-    line => "exclude\t${name}",
+  concat::fragment { 'rsnapshot_exclusions':
+    target  => $rsnapshot::params::config_path,
+    content => template('rsnapshot/rsnapshot.conf.erb'),
+    order   => '10',
   }
 }

--- a/manifests/master/node_definition.pp
+++ b/manifests/master/node_definition.pp
@@ -1,32 +1,14 @@
 define rsnapshot::master::node_definition(
-    $ensure=present,
-    $to_location,
-    $sshdsakey,
-    $sshrsakey,
-    $ipaddress) {
+  $ensure = present,
+  $to_location,
+  $identifier,
+  $ipaddress,
+  $backup = {},
+) {
 
-  file_line { "$name old name based backups":
-    ensure => 'absent',
-    path   => '/etc/rsnapshot.conf',
-    line   => "backup\troot@$name:/\t$name/",
-  }
-
-  file_line { "$name backups":
-    ensure => $ensure,
-    path   => '/etc/rsnapshot.conf',
-    line   => "backup\troot@$ipaddress:/\t$name/",
-  }
-
-  sshkey { "${name}_dsa":
-    ensure       => $ensure,
-    type         => 'dsa',
-    key          => $sshdsakey,
-    host_aliases => [$name, $ipaddress],
-  }
-  sshkey { "${name}_rsa":
-    ensure       => $ensure,
-    type         => 'rsa',
-    key          => $sshrsakey,
-    host_aliases => [$name, $ipaddress],
+  concat::fragment { "rsnapshot_node_${name}":
+    target  => $rsnapshot::params::config_path,
+    content => template('rsnapshot/rsnapshot_node.conf.erb'),
+    order   => '50',
   }
 }

--- a/manifests/master/node_definition.pp
+++ b/manifests/master/node_definition.pp
@@ -3,9 +3,9 @@ define rsnapshot::master::node_definition(
   $to_location,
   $identifier,
   $ipaddress,
-  $backup = {},
+  $backup = [],
 ) {
-
+  $backup_array = any2array($backup)
   concat::fragment { "rsnapshot_node_${name}":
     target  => $rsnapshot::params::config_path,
     content => template('rsnapshot/rsnapshot_node.conf.erb'),

--- a/manifests/master/node_definition.pp
+++ b/manifests/master/node_definition.pp
@@ -4,11 +4,15 @@ define rsnapshot::master::node_definition(
   $identifier,
   $ipaddress,
   $backup = [],
+  $export_sshkeys,
 ) {
   $backup_array = any2array($backup)
   concat::fragment { "rsnapshot_node_${name}":
     target  => $rsnapshot::params::config_path,
     content => template('rsnapshot/rsnapshot_node.conf.erb'),
     order   => '50',
+  }
+  if $export_sshkeys {
+    include rsnapshot::sshkeys
   }
 }

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -1,11 +1,17 @@
-class rsnapshot::node($to_location, $ensure=present) {
+class rsnapshot::node(
+  $to_location,
+  $ensure     = present,
+  $identifier = $::fqdn,
+  $ipaddress  = $::ipaddress,
+  $backup     = {},
+) {
 
-  @@rsnapshot::master::node_definition { $fqdn:
+  @@rsnapshot::master::node_definition { $identifier:
     ensure      => $ensure,
     to_location => $to_location,
-    ipaddress   => $::ipaddress,
-    sshdsakey   => $::sshdsakey,
-    sshrsakey   => $::sshrsakey,
+    identifier  => $identifier,
+    ipaddress   => $ipaddress,
+    backup      => $backup,
   }
 
   Rsnapshot::Node::Master_definition <<| location_name == $to_location |>>

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -4,14 +4,17 @@ class rsnapshot::node(
   $identifier = $::fqdn,
   $ipaddress  = $::ipaddress,
   $backup     = {},
+  $export_sshkeys = true,
+  $sshkey_aliases = [$identifier, $::ipaddress],
 ) {
 
   @@rsnapshot::master::node_definition { $identifier:
-    ensure      => $ensure,
-    to_location => $to_location,
-    identifier  => $identifier,
-    ipaddress   => $ipaddress,
-    backup      => $backup,
+    ensure         => $ensure,
+    to_location    => $to_location,
+    identifier     => $identifier,
+    ipaddress      => $ipaddress,
+    backup         => $backup,
+    export_sshkeys => $export_sshkeys,
   }
 
   Rsnapshot::Node::Master_definition <<| location_name == $to_location |>>

--- a/manifests/node/master_definition.pp
+++ b/manifests/node/master_definition.pp
@@ -1,4 +1,7 @@
-define rsnapshot::node::master_definition($location_name, $sshpubkey) {
+define rsnapshot::node::master_definition(
+  $location_name,
+  $sshpubkey
+) {
 
   if ($sshpubkey !~ /^(ssh-...) ([^ ]*)/) {
     err("Can't parse key from root@$name")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,8 +15,19 @@ class rsnapshot::params {
   $loglevel = '3'
   $logfile  = '/var/log/rsnapshot.log'
   $retain = {
-    'hourly' => '4',
-    'daily'  => '7',
-    'weekly' => '4',
+    'hourly'  => '6',
+    'daily'   => '7',
+    'weekly'  => '4',
+    'monthly' => '3',
   }
+  $hourly_hour   = '*/4'
+  $hourly_minute = '0'
+  $daily_hour    = '23'
+  $daily_minute  = '50'
+  $weekly_hour    = '23'
+  $weekly_minute  = '40'
+  $weekly_weekday = '6'
+  $monthly_hour     = '23'
+  $monthly_minute   = '30'
+  $monthly_monthday = '1'
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,9 +3,20 @@ class rsnapshot::params {
     'Debian': {
       $pkg = 'rsnapshot'
       $config_path = '/etc/rsnapshot.conf'
+      $builtin_exclusions = ['dev', 'proc', 'sys', 'run', 'tmp']
     }
     default: {
       fail('Unsupported operating system')
     }
+  }
+  $snapshot_root = '/var/backups/rsnapshot'
+  $options  = []
+  $verbose  = '2'
+  $loglevel = '3'
+  $logfile  = '/var/log/rsnapshot.log'
+  $retain = {
+    'hourly' => '4',
+    'daily'  => '7',
+    'weekly' => '4',
   }
 }

--- a/manifests/sshkeys.pp
+++ b/manifests/sshkeys.pp
@@ -1,0 +1,46 @@
+class rsnapshot::sshkeys inherits rsnapshot::node {
+  case $::sshrsakey {
+    "": {
+      err("no sshrsakey on $::fqdn")
+    }
+    default: {
+      @@sshkey { "${::hostname}.${::domain}-ssh-rsa":
+        type         => ssh-rsa,
+        host_aliases => [$sshkey_aliases],
+        key          => $::sshrsakey,
+        ensure       => present,
+        tag          => $::fqdn,
+      }
+    }
+  }
+
+  case $::sshdsakey {
+    "": {
+      err("no sshdsakey on $::fqdn")
+    }
+    default: {
+      @@sshkey { "${::hostname}.${::domain}-ssh-dsa":
+        type         => ssh-dss,
+        host_aliases => [$sshkey_aliases],
+        key          => $::sshdsakey,
+        ensure       => present,
+        tag          => $::fqdn,
+      }
+    }
+  }
+
+  case $::sshecdsakey {
+    "": {
+      err("no sshecdsakey on $::fqdn")
+    }
+    default: {
+      @@sshkey { "${::hostname}.${::domain}-ssh-ecdsa":
+        type         => 'ecdsa-sha2-nistp256',
+        host_aliases => [$sshkey_aliases],
+        key          => $::sshecdsakey,
+        ensure       => present,
+        tag          => $::fqdn,
+      }
+    }
+  }
+}

--- a/templates/exclusions.conf.erb
+++ b/templates/exclusions.conf.erb
@@ -1,0 +1,3 @@
+<% @all_exclusions.each do |value| -%>
+exclude	<%= value %>
+<% end -%>

--- a/templates/rsnapshot.conf.erb
+++ b/templates/rsnapshot.conf.erb
@@ -1,0 +1,233 @@
+#################################################
+# rsnapshot.conf - rsnapshot configuration file #
+#################################################
+#                                               #
+# PLEASE BE AWARE OF THE FOLLOWING RULES:       #
+#                                               #
+# This file requires tabs between elements      #
+#                                               #
+# Directories require a trailing slash:         #
+#   right: /home/                               #
+#   wrong: /home                                #
+#                                               #
+#################################################
+
+#######################
+# CONFIG FILE VERSION #
+#######################
+
+config_version	1.2
+
+###########################
+# SNAPSHOT ROOT DIRECTORY #
+###########################
+
+# All snapshots will be stored under this root directory.
+#
+snapshot_root	<%= @snapshot_root %>
+
+# If no_create_root is enabled, rsnapshot will not automatically create the
+# snapshot_root directory. This is particularly useful if you are backing
+# up to removable media, such as a FireWire or USB drive.
+#
+#no_create_root	1
+
+#################################
+# EXTERNAL PROGRAM DEPENDENCIES #
+#################################
+
+# LINUX USERS:   Be sure to uncomment "cmd_cp". This gives you extra features.
+# EVERYONE ELSE: Leave "cmd_cp" commented out for compatibility.
+#
+# See the README file or the man page for more details.
+#
+cmd_cp		/bin/cp
+
+# uncomment this to use the rm program instead of the built-in perl routine.
+#
+cmd_rm		/bin/rm
+
+# rsync must be enabled for anything to work. This is the only command that
+# must be enabled.
+#
+cmd_rsync	/usr/bin/rsync
+
+# Uncomment this to enable remote ssh backups over rsync.
+#
+cmd_ssh	/usr/bin/ssh
+
+# Comment this out to disable syslog support.
+#
+cmd_logger	/usr/bin/logger
+
+# Uncomment this to specify the path to "du" for disk usage checks.
+# If you have an older version of "du", you may also want to check the
+# "du_args" parameter below.
+#
+#cmd_du		/usr/bin/du
+
+# Uncomment this to specify the path to rsnapshot-diff.
+#
+#cmd_rsnapshot_diff	/usr/bin/rsnapshot-diff
+
+# Specify the path to a script (and any optional arguments) to run right
+# before rsnapshot syncs files
+#
+#cmd_preexec	/path/to/preexec/script
+
+# Specify the path to a script (and any optional arguments) to run right
+# after rsnapshot syncs files
+#
+#cmd_postexec	/path/to/postexec/script
+
+# Paths to lvcreate, lvremove, mount and umount commands, for use with
+# Linux LVMs.
+#
+#linux_lvm_cmd_lvcreate	/sbin/lvcreate
+#linux_lvm_cmd_lvremove	/sbin/lvremove
+#linux_lvm_cmd_mount	/bin/mount
+#linux_lvm_cmd_umount	/bin/umount
+
+#########################################
+#           BACKUP INTERVALS            #
+# Must be unique and in ascending order #
+# i.e. hourly, daily, weekly, etc.      #
+#########################################
+
+<% @retain.each do |key, value| -%>
+retain	<%= key %>	<%= value %>
+<% end -%>
+
+
+############################################
+#              GLOBAL OPTIONS              #
+# All are optional, with sensible defaults #
+############################################
+
+# Verbose level, 1 through 5.
+# 1     Quiet           Print fatal errors only
+# 2     Default         Print errors and warnings only
+# 3     Verbose         Show equivalent shell commands being executed
+# 4     Extra Verbose   Show extra verbose information
+# 5     Debug mode      Everything
+#
+verbose		<%= @verbose %>
+
+# Same as "verbose" above, but controls the amount of data sent to the
+# logfile, if one is being used. The default is 3.
+#
+loglevel	<%= @loglevel_ %>
+
+# If you enable this, data will be written to the file you specify. The
+# amount of data written is controlled by the "loglevel" parameter.
+#
+logfile	<%= @logfile %>
+
+# If enabled, rsnapshot will write a lockfile to prevent two instances
+# from running simultaneously (and messing up the snapshot_root).
+# If you enable this, make sure the lockfile directory is not world
+# writable. Otherwise anyone can prevent the program from running.
+#
+lockfile	/var/run/rsnapshot.pid
+
+# By default, rsnapshot check lockfile, check if PID is running
+# and if not, consider lockfile as stale, then start
+# Enabling this stop rsnapshot if PID in lockfile is not running
+#
+#stop_on_stale_lockfile		0
+
+# Default rsync args. All rsync commands have at least these options set.
+#
+#rsync_short_args	-a
+#rsync_long_args	--delete --numeric-ids --relative --delete-excluded
+
+# ssh has no args passed by default, but you can specify some here.
+#
+#ssh_args	-p 22
+
+# Default arguments for the "du" program (for disk space reporting).
+# The GNU version of "du" is preferred. See the man page for more details.
+# If your version of "du" doesn't support the -h flag, try -k flag instead.
+#
+#du_args	-csh
+
+# If this is enabled, rsync won't span filesystem partitions within a
+# backup point. This essentially passes the -x option to rsync.
+# The default is 0 (off).
+#
+#one_fs		0
+
+# The include and exclude parameters, if enabled, simply get passed directly
+# to rsync. If you have multiple include/exclude patterns, put each one on a
+# separate line. Please look up the --include and --exclude options in the
+# rsync man page for more details on how to specify file name patterns. 
+# 
+#include	???
+#include	???
+#exclude	???
+#exclude	???
+
+# The include_file and exclude_file parameters, if enabled, simply get
+# passed directly to rsync. Please look up the --include-from and
+# --exclude-from options in the rsync man page for more details.
+#
+#include_file	/path/to/include/file
+#exclude_file	/path/to/exclude/file
+
+# If your version of rsync supports --link-dest, consider enable this.
+# This is the best way to support special files (FIFOs, etc) cross-platform.
+# The default is 0 (off).
+#
+#link_dest	0
+
+# When sync_first is enabled, it changes the default behaviour of rsnapshot.
+# Normally, when rsnapshot is called with its lowest interval
+# (i.e.: "rsnapshot hourly"), it will sync files AND rotate the lowest
+# intervals. With sync_first enabled, "rsnapshot sync" handles the file sync,
+# and all interval calls simply rotate files. See the man page for more
+# details. The default is 0 (off).
+#
+#sync_first	0
+
+# If enabled, rsnapshot will move the oldest directory for each interval
+# to [interval_name].delete, then it will remove the lockfile and delete
+# that directory just before it exits. The default is 0 (off).
+#
+#use_lazy_deletes	0
+
+# Number of rsync re-tries. If you experience any network problems or
+# network card issues that tend to cause ssh to crap-out with
+# "Corrupted MAC on input" errors, for example, set this to a non-zero
+# value to have the rsync operation re-tried
+#
+#rsync_numtries 0
+
+# LVM parameters. Used to backup with creating lvm snapshot before backup
+# and removing it after. This should ensure consistency of data in some special
+# cases
+#
+# LVM snapshot(s) size (lvcreate --size option).
+#
+#linux_lvm_snapshotsize	100M
+
+# Name to be used when creating the LVM logical volume snapshot(s).
+#
+#linux_lvm_snapshotname	rsnapshot
+
+# Path to the LVM Volume Groups.
+#
+#linux_lvm_vgpath	/dev
+
+# Mount point to use to temporarily mount the snapshot(s).
+#
+#linux_lvm_mountpath	/path/to/mount/lvm/snapshot/during/backup
+<% if !@options.empty? -%>
+<% @options.each do |key, value| -%>
+<%= key %>	<%= value %>
+<% end -%>
+<% end -%>
+
+###############################
+### BACKUP POINTS / SCRIPTS ###
+###############################
+

--- a/templates/rsnapshot_node.conf.erb
+++ b/templates/rsnapshot_node.conf.erb
@@ -1,0 +1,3 @@
+<% @backup.each do |value| -%>
+backup	root@<%= @ipaddress %>:<%= value %>	<%= @identifier %><%= value %>
+<% end -%>

--- a/templates/rsnapshot_node.conf.erb
+++ b/templates/rsnapshot_node.conf.erb
@@ -1,3 +1,3 @@
-<% @backup.each do |value| -%>
+<% @backup_array.each do |value| -%>
 backup	root@<%= @ipaddress %>:<%= value %>	<%= @identifier %><%= value %>
 <% end -%>


### PR DESCRIPTION
This is a major refactoring of the code that handle per client backup path.
It makes uses of concat/template instead of file_line pattern.

Also add flexible cron management, and move many parameters to the standard "params" class.

Remove sshkey (for hosts) management as it don't think it belongs within this module specifically, it can be declared at a much higher level.
